### PR TITLE
Modify trap class import for compatibility with current arcticpy

### DIFF
--- a/emccd_detect/emccd_detect.py
+++ b/emccd_detect/emccd_detect.py
@@ -11,7 +11,13 @@ from emccd_detect.cosmics import cosmic_hits, sat_tails
 from emccd_detect.rand_em_gain import rand_em_gain
 from emccd_detect.util.read_metadata_wrapper import MetadataWrapper
 from arcticpy import add_cti, CCD, ROE
-from arcticpy import TrapInstantCapture as Trap
+try:
+    from arcticpy import Trap
+except ImportError:
+    try:
+        from arcticpy import TrapInstantCapture as Trap
+    except Exception:
+        raise Exception("Failed to import articpy trap class.")
 
 
 class EMCCDDetectException(Exception):

--- a/emccd_detect/emccd_detect.py
+++ b/emccd_detect/emccd_detect.py
@@ -10,7 +10,8 @@ import numpy as np
 from emccd_detect.cosmics import cosmic_hits, sat_tails
 from emccd_detect.rand_em_gain import rand_em_gain
 from emccd_detect.util.read_metadata_wrapper import MetadataWrapper
-from arcticpy import add_cti, CCD, ROE, Trap
+from arcticpy import add_cti, CCD, ROE
+from arcticpy import TrapInstantCapture as Trap
 
 
 class EMCCDDetectException(Exception):


### PR DESCRIPTION
The arcticpy version installed by the emccd_current setup script no longer has a Trap() class (see https://github.com/jkeger/arctic/blob/master/python/arcticpy/__init__.py). As a result, upon a install the emccd_detect example script triggers an import error:
`ImportError: cannot import name 'Trap' from 'arcticpy' (/Users/nzimmerm/anaconda3/envs/py39/lib/python3.9/site-packages/arcticpy/__init__.py)
`

I fixed this by modifying the class import statement at the top of emccd_detect.py.